### PR TITLE
Gain selection and combined images

### DIFF
--- a/dl1_data_handler/writer.py
+++ b/dl1_data_handler/writer.py
@@ -765,6 +765,10 @@ def gain_selection(waveform, signals, peakpos, cam_id, threshold):
     peakpos: array of pixel peak positions
     cam_id: str
     threshold: int threshold to change form high gain to low gain
+
+    Returns
+    -------
+    combined_image, combined_peakpos: `(numpy.array, numpy.array)`
     """
 
     gainsel = ThresholdGainSelector(select_by_sample=True)
@@ -784,6 +788,7 @@ def gain_selection(waveform, signals, peakpos, cam_id, threshold):
 def combine_channels(event):
     """
     Combine the channels for the image and peakpos arrays in the event.dl1 containers
+    The `event.dl1.tel[tel_id].image` and `event.dl1.tel[tel_id].peakpos` are replaced by their combined versions
 
     Parameters
     ----------

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,0 +1,23 @@
+from dl1_data_handler import writer as w
+import numpy as np
+
+
+
+def test_gain_selection():
+    """
+    test gain selection
+    """
+    # Let's generate a fake waveform from a camera of 3 samples and 10 pixels
+    n_samples = 3
+    w1 = np.transpose([np.concatenate([np.ones(5), 3 * np.ones(5)]) for i in range(n_samples)])
+    w2 = np.transpose([10 * np.ones(10) for i in range(n_samples)])
+    waveform = np.array([w1, w2])
+    image = waveform.mean(axis=2)
+
+    threshold = 2
+    combined_image, combined_peakpos = w.gain_selection(waveform, image, image, 'LSTCam', threshold)
+
+    # with a threshold of 2, the 5 first pixels should be selected in the first channel and 5 others in the second \
+    # channel
+
+    np.testing.assert_array_equal(combined_image, np.array([1, 1, 1, 1, 1, 10, 10, 10, 10, 10]))


### PR DESCRIPTION
Adding functions to apply channel selection.

The cameras saturation threshold are set in a dictionnary in the script.
I set them at the prod3b value. They are most probably the same for the NSB dataset but we should double check it.

Then the gain selection is done this way:
- if the camera has two channels:
    - the non-saturated pixels are taken from the first channel
    - the saturated pixels are taken from second channel
    - both are combined in one calibrated image and peakpos map
- if the camera has one channel, the first and only channel is selected

The image and peakpos are replaced by their combined version directly in the `event.dl1.tel[tel_id]` container, so image and peakpos have two dimensions only at the end (instead of three with the channels).

Added a test for the gain selection.
