### PR TITLE
Add dimension to gain mask if ndim equals 1

### DIFF
--- a/dl1_data_handler/writer.py
+++ b/dl1_data_handler/writer.py
@@ -987,7 +987,6 @@ class DL1DataWriter:
             combined_image.shape = image.shape[1]
         """
 
-        # print(image.shape[0] == 2)
         assert image.shape[0] == 2
 
         self.gain_selector.thresholds[cam_id] = threshold

--- a/dl1_data_handler/writer.py
+++ b/dl1_data_handler/writer.py
@@ -987,11 +987,15 @@ class DL1DataWriter:
             combined_image.shape = image.shape[1]
         """
 
+        # print(image.shape[0] == 2)
         assert image.shape[0] == 2
 
         self.gain_selector.thresholds[cam_id] = threshold
 
         waveform, gain_mask = self.gain_selector.select_gains(cam_id, waveform)
+        if gain_mask.ndim == 1:
+            gain_mask = gain_mask[:, None]
+
         signal_mask = gain_mask.max(axis=1)
 
         combined_image = image[0].copy()


### PR DESCRIPTION
Fixes an error which occurs when the `gain_selector.select_gains` returns an unexpected dimension.
Lets call this a hotfix since I have no idea what this is doing exactly. And why. 