### PR TITLE
Added a new mapping method 

### DIFF
--- a/dl1_data_handler/image_mapper.py
+++ b/dl1_data_handler/image_mapper.py
@@ -85,9 +85,9 @@ class ImageMapper:
 
             map_method = self.mapping_method[camtype]
             if map_method not in ['oversampling', 'rebinning', 'nearest_interpolation', 'bilinear_interpolation',
-                                  'bicubic_interpolation', 'image_shifting', 'axial_addressing', 'IndexedConv']:
+                                  'bicubic_interpolation', 'image_shifting', 'axial_addressing', 'indexed_conv']:
                 raise ValueError("Hex conversion algorithm {} is not implemented.".format(map_method))
-            elif map_method in ['image_shifting', 'axial_addressing', 'IndexedConv'] and camtype in ['ASTRICam', 'CHEC', 'SCTCam']:
+            elif map_method in ['image_shifting', 'axial_addressing', 'indexed_conv'] and camtype in ['ASTRICam', 'CHEC', 'SCTCam']:
                 raise ValueError(
                     "{} (hexagonal convolution) is not available for square pixel cameras.".format(map_method))
 
@@ -97,7 +97,7 @@ class ImageMapper:
             # At the edges of the cameras the mapping methods run into issues.
             # Therefore, we are using a default padding to ensure that the camera pixels aren't affected.
             # The default padding is removed after the conversion is finished.
-            if map_method in ['image_shifting', 'axial_addressing', 'IndexedConv']:
+            if map_method in ['image_shifting', 'axial_addressing', 'indexed_conv']:
                 self.default_pad = 0
             elif map_method == 'bicubic_interpolation':
                 self.default_pad = 3
@@ -155,7 +155,7 @@ class ImageMapper:
         """
         # Check if axial addressing is selected in the image_mapper
         if self.index_matrixes[camera_type] is None:
-            raise ValueError("The function get_indexmatrix() can only be called, when 'IndexedConv' is selected in the ImageMapper.")
+            raise ValueError("The function get_indexmatrix() can only be called, when 'indexed_conv' is selected in the ImageMapper.")
         # Return the index matrix, which has been calculated in 'generate_table()'
         return self.index_matrixes[camera_type]
 
@@ -184,12 +184,12 @@ class ImageMapper:
         output_dim = self.image_shapes[camera_type][0]
 
         # Oversampling and nearest interpolation
-        if map_method in ['oversampling', 'nearest_interpolation', 'image_shifting', 'axial_addressing', 'IndexedConv']:
+        if map_method in ['oversampling', 'nearest_interpolation', 'image_shifting', 'axial_addressing', 'indexed_conv']:
             # Finding the nearest point in the hexagonal grid for each point in the square grid
             tree = spatial.cKDTree(hex_grid)
             nn_index = np.reshape(tree.query(table_grid)[1], (output_dim, output_dim))
             # Store the nn_index array in the index_matrix. Replace virtual pixel indexes with -1.
-            if map_method == 'IndexedConv':
+            if map_method == 'indexed_conv':
                 index_matrix = nn_index
                 index_matrix[index_matrix >= num_pixels] = -1
                 index_matrix = np.flip(index_matrix, axis=0)
@@ -513,7 +513,7 @@ class ImageMapper:
         if self.mask and map_method in ['bilinear_interpolation', 'bicubic_interpolation']:
             mapping_matrix3d = self.apply_mask_interpolation(mapping_matrix3d, nn_index, num_pixels, pad)
         # Rotating the camera back to the original orientation
-        if self.rot_cam and camera_type in ['LSTCam', 'NectarCam', 'MAGICCam'] and map_method not in ['image_shifting', 'axial_addressing', 'IndexedConv']:
+        if self.rot_cam and camera_type in ['LSTCam', 'NectarCam', 'MAGICCam'] and map_method not in ['image_shifting', 'axial_addressing', 'indexed_conv']:
              mapping_matrix3d = self.rotate_mapping_table(mapping_matrix3d,90.0-CameraGeometry.from_name(camera_type).pix_rotation.deg)
         # Normalization (approximation) of the mapping table
         if map_method in ['rebinning', 'bilinear_interpolation', 'bicubic_interpolation']:
@@ -783,7 +783,7 @@ class ImageMapper:
                 second_ticks.insert(0, np.around(second_ticks[0] - dist_second, decimals=3))
 
             # Create the virtual pixels outside of the camera
-            if map_method not in ['axial_addressing', 'IndexedConv']:
+            if map_method not in ['axial_addressing', 'indexed_conv']:
                 virtual_pixels = []
                 for i in np.arange(2):
                     if map_method in ['oversampling', 'image_shifting']:
@@ -822,7 +822,7 @@ class ImageMapper:
                 grid_second = np.unique(second_pos).tolist()
                 self.image_shapes[camera_type] = (len(grid_first), len(grid_second), self.image_shapes[camera_type][2])
 
-            elif map_method in ['axial_addressing', 'IndexedConv']:
+            elif map_method in ['axial_addressing', 'indexed_conv']:
                 virtual_pixels = []
                 # manipulate y ticks with extra ticks
                 num_extra_ticks = len(y_ticks)

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -330,7 +330,7 @@ class DL1DataReader:
     # Get a single telescope image from a particular event, uniquely
     # identified by the filename, tel_type, and image table index.
     # First extract a raw 1D vector and transform it into a 2D image using a
-    # mapping table. When 'IndexedConv' is selected this function should
+    # mapping table. When 'indexed_conv' is selected this function should
     # return the unmapped vector.
     def _get_image(self, filename, tel_type, image_index):
 
@@ -345,8 +345,8 @@ class DL1DataReader:
         # image of all zeros with be loaded
         for i, channel in enumerate(self.image_channels):
             vector[:, i] = record[channel]
-        # If 'IndexedConv' is selected, we only need the unmapped vector.
-        if self.image_mapper.mapping_method[get_camera_type(tel_type)] == 'IndexedConv':
+        # If 'indexed_conv' is selected, we only need the unmapped vector.
+        if self.image_mapper.mapping_method[get_camera_type(tel_type)] == 'indexed_conv':
            return vector
         image = self.image_mapper.map_image(vector, get_camera_type(tel_type))
         return image

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -330,7 +330,7 @@ class DL1DataReader:
     # Get a single telescope image from a particular event, uniquely
     # identified by the filename, tel_type, and image table index.
     # First extract a raw 1D vector and transform it into a 2D image using a
-    # mapping table. When 'axial addressing' is selected this function should
+    # mapping table. When 'IndexedConv' is selected this function should
     # return the unmapped vector.
     def _get_image(self, filename, tel_type, image_index):
 
@@ -345,8 +345,8 @@ class DL1DataReader:
         # image of all zeros with be loaded
         for i, channel in enumerate(self.image_channels):
             vector[:, i] = record[channel]
-        # If axial addressing is selected, we only need the unmapped vector.
-        if self.image_mapper.mapping_method[get_camera_type(tel_type)] == 'axial_addressing':
+        # If 'IndexedConv' is selected, we only need the unmapped vector.
+        if self.image_mapper.mapping_method[get_camera_type(tel_type)] == 'IndexedConv':
            return vector
         image = self.image_mapper.map_image(vector, get_camera_type(tel_type))
         return image


### PR DESCRIPTION
I "added" a new mapping method called 'IndexedConv', which will be the input (unmapped vector) for the [IndexedConv](https://github.com/IndexedConv/IndexedConv) package. With get_indexmatrix() one can retrieve the index matrix (as before), which is also needed for IndexedConv. The output for 'axial_addressing' in the ImageMapper is now a **2D** images, which can be used for masked convolution layers.