### PR TITLE
moved pyirf

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,3 @@
-.. role:: raw-html-m2r(raw)
-   :format: html
-
-
 DL1 Data Handler
 ================
 
@@ -16,12 +12,22 @@ DL1 Data Handler
    :alt: build status
 
 
+.. image:: https://anaconda.org/ctlearn-project/dl1_data_handler/badges/installer/conda.svg
+   :target: https://anaconda.org/ctlearn-project/dl1_data_handler/
+   :alt: Anaconda-Server Badge
+
+
+.. image:: https://img.shields.io/pypi/v/dl1-data-handler
+    :target: https://pypi.org/project/dl1-data-handler/
+    :alt: Latest Release
+
+
 .. image:: https://coveralls.io/repos/github/cta-observatory/dl1-data-handler/badge.svg?branch=master
    :target: https://coveralls.io/github/cta-observatory/dl1-data-handler?branch=master
    :alt: Coverage Status
 
 
-A package of utilities for writing (deprecated), reading, and applying image processing to :raw-html-m2r:`<a href="https://www.cta-observatory.org/" title="CTA collaboration Homepage">Cherenkov Telescope Array (CTA)</a>` DL1 data (calibrated images) in a standardized format. Created primarily for testing machine learning image analysis techniques on IACT data.
+A package of utilities for writing (deprecated), reading, and applying image processing to `Cherenkov Telescope Array (CTA) <https://www.cta-observatory.org/>`_\ DL1 data (calibrated images) in a standardized format. Created primarily for testing machine learning image analysis techniques on IACT data.
 
 Currently supports data in the CTA pyhessio sim_telarray format, with the possibility of supporting other IACT data formats in the future. Built using ctapipe and PyTables.
 
@@ -49,7 +55,7 @@ necessary package channels, and install dl1-data-handler specified version and i
 
 .. code-block:: bash
 
-   DL1DH_VER=0.10.1
+   DL1DH_VER=0.10.2
    wget https://raw.githubusercontent.com/cta-observatory/dl1-data-handler/v$DL1DH_VER/environment.yml
    conda env create -n [ENVIRONMENT_NAME] -f environment.yml
    conda activate [ENVIRONMENT_NAME]
@@ -57,12 +63,12 @@ necessary package channels, and install dl1-data-handler specified version and i
 
 This should automatically install all dependencies (NOTE: this may take some time, as by default MKL is included as a dependency of NumPy and it is very large).
 
-If you want to import any functionality from dl1-data-handler into your own Python scripts, then you are all set. However, if you wish to make use of any of the scripts in dl1-data-handler/scripts (like write_data.py), you should also clone the repository locally and checkout the corresponding tag (i.e. for version v0.10.1): 
+If you want to import any functionality from dl1-data-handler into your own Python scripts, then you are all set. However, if you wish to make use of any of the scripts in dl1-data-handler/scripts (like write_data.py), you should also clone the repository locally and checkout the corresponding tag (i.e. for version v0.10.2): 
 
 .. code-block:: bash
 
    git clone https://github.com/cta-observatory/dl1-data-handler.git
-   git checkout v0.10.1
+   git checkout v0.10.2
 
 dl1-data-handler should already have been installed in your environment by Conda, so no further installation steps (i.e. with setuptools or pip) are necessary and you should be able to run scripts/write_data.py directly.
 
@@ -189,7 +195,8 @@ Links
 -----
 
 
-* :raw-html-m2r:`<a href="https://www.cta-observatory.org/" title="CTA collaboration Homepage">Cherenkov Telescope Array (CTA)</a>` - Homepage of the CTA collaboration
-* :raw-html-m2r:`<a href="https://github.com/ctlearn-project/ctlearn" title="CTLearn Repository">CTLearn</a>` and :raw-html-m2r:`<a href="https://gitlab.lapp.in2p3.fr/GammaLearn/GammaLearn" title="GammaLearn Repository">GammaLearn</a>` - Repository of code for studies on applying deep learning to IACT analysis tasks. Maintained by groups at Columbia University, Universidad Complutense de Madrid, Barnard College (CTLearn) and LAPP (GammaLearn).
-* :raw-html-m2r:`<a href="https://cta-observatory.github.io/ctapipe/" title="ctapipe Official Documentation Page">ctapipe</a>` - Official documentation for the ctapipe analysis package (in development)
-* :raw-html-m2r:`<a href="http://vitables.org/" title="ViTables Homepage">ViTables</a>` - Homepage for ViTables application for Pytables HDF5 file visualization
+* `Cherenkov Telescope Array (CTA) <https://www.cta-observatory.org/>`_\ - Homepage of the CTA collaboration 
+* `CTLearn <https://github.com/ctlearn-project/ctlearn/>`_\ and `GammaLearn <https://gitlab.lapp.in2p3.fr/GammaLearn/GammaLearn>`_\ - Repository of code for studies on applying deep learning to IACT analysis tasks. Maintained by groups at Columbia University, Universidad Complutense de Madrid, Barnard College (CTLearn) and LAPP (GammaLearn).
+* `ctapipe <https://cta-observatory.github.io/ctapipe/>`_\ - Official documentation for the ctapipe analysis package (in development)
+* `ViTables <http://vitables.org/>`_\ - Homepage for ViTables application for Pytables HDF5 file visualization
+

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -16,7 +16,6 @@ from astropy.table import (
     join,  # let us merge tables horizontally
     vstack,  # and vertically
 )
-from pyirf.simulations import SimulatedEventsInfo
 
 __all__ = ["DL1DataReader", "DL1DataReaderSTAGE1", "DL1DataReaderDL1DH"]
 
@@ -818,17 +817,6 @@ class DL1DataReaderSTAGE1(DL1DataReader):
                     len(self.image_channels),  # number of channels
                 )
 
-        if self.event_info:
-            # Created pyIRF SimulatedEventsInfo
-            self.pyIRFSimulatedEventsInfo = SimulatedEventsInfo(
-                n_showers=int(self.simulation_info["num_showers"]),
-                energy_min=u.Quantity(self.simulation_info["energy_range_min"], u.TeV),
-                energy_max=u.Quantity(self.simulation_info["energy_range_max"], u.TeV),
-                max_impact=u.Quantity(self.simulation_info["max_scatter_range"], u.m),
-                spectral_index=self.simulation_info["spectral_index"],
-                viewcone=u.Quantity(self.simulation_info["max_viewcone_radius"], u.deg),
-            )
-
         if self.pointing_mode == "fix_subarray":
             subarray_pointing = self.files[
                 first_file
@@ -1529,17 +1517,6 @@ class DL1DataReaderDL1DH(DL1DataReader):
         if shuffle:
             random.seed(seed)
             random.shuffle(self.example_identifiers)
-
-        if self.event_info:
-            # Created pyIRF SimulatedEventsInfo
-            self.pyIRFSimulatedEventsInfo = SimulatedEventsInfo(
-                n_showers=int(self.simulation_info["num_showers"]),
-                energy_min=u.Quantity(self.simulation_info["energy_range_min"], u.GeV),
-                energy_max=u.Quantity(self.simulation_info["energy_range_max"], u.GeV),
-                max_impact=u.Quantity(self.simulation_info["max_scatter_range"], u.cm),
-                spectral_index=self.simulation_info["spectral_index"],
-                viewcone=u.Quantity(self.simulation_info["max_viewcone_radius"], u.deg),
-            )
 
         if self.pointing_mode == "fix_subarray":
             run_array_direction = self.files[first_file].root._v_attrs[

--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
     - numpy
     - pip
     - pyyaml
+    - pandas
     - pip:
         - ctapipe==0.12.0
         - pydot

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,5 @@ dependencies:
     - pyyaml
     - pip:
         - ctapipe==0.12.0
-        - pyirf
-        - ctaplot
         - pydot
 

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: dl1_data_handler
-  version: "0.10.1"
+  version: "0.10.2"
 
 source:
   git_url: https://github.com/cta-observatory/dl1-data-handler.git
-  git_rev: v0.10.1
+  git_rev: v0.10.2
 
 build:
   noarch: generic
@@ -17,18 +17,21 @@ requirements:
     - jupyter
     - ctapipe ==0.12.0
     - pytables >=3.4.4 
+    - pandas
   host:
     - python >=3.8
     - numpy >=1.15.0
     - jupyter
     - ctapipe ==0.12.0
     - pytables >=3.4.4
+    - pandas
   run:
     - python >=3.8
     - numpy >=1.15.0
     - jupyter
     - ctapipe ==0.12.0
     - pytables >=3.4.4
+    - pandas
   test:
     imports:
       - dl1-data-handler

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(
         "ctapipe==0.12.0",
         "jupyter",
         "pytest-cov",
-        "pyirf",
         "tables",
     ],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         "astropy>=4.0.5,<5",
         "ctapipe==0.12.0",
         "jupyter",
+        "pandas",
         "pytest-cov",
         "tables",
     ],
@@ -30,7 +31,7 @@ setup(
         "console_scripts": [
             "dl1dh-generate_runlist=dl1_data_handler.generate_runlist:main",
             "dl1dh-write_data=dl1_data_handler.write_data:main",
-        ],
+        ]
     },
     dependency_links=[],
     zip_safe=True,


### PR DESCRIPTION
It turned out to be unpractical to predict on the whole test sets at once, which makes the creation of the `SimulatedEventsInfo` inside the reader redundant.