### PR TITLE
bug fix - select tel id for stage1 datasets split by tel_type

### DIFF
--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -446,23 +446,16 @@ class DL1DataReaderSTAGE1(DL1DataReader):
                 if "Subarray" not in multiplicity_selection:
                     multiplicity_selection["Subarray"] = subarray_multiplicity
 
+                # Construct the shower simulation table
+                simshower_table = read_table(f, "/simulation/event/subarray/shower")
+                simshower_table.add_column(
+                    np.arange(len(simshower_table)), name="sim_index", index=0
+                )
+                true_shower_primary_id = simshower_table["true_shower_primary_id"][0]
+
                 # Construct the example identifiers for 'mono' or 'stereo' mode.
                 example_identifiers = []
                 if self.mode == "mono":
-
-                    simshower_table = read_table(
-                        f, "/simulation/event/subarray/shower"
-                    )
-
-                    true_shower_primary_id = simshower_table[
-                        "true_shower_primary_id"
-                    ][0]
-
-                    simshower_table.add_column(
-                        np.arange(len(simshower_table)),
-                        name="sim_index",
-                        index=0,
-                    )
 
                     if self.split_datasets_by == "tel_id":
                         # Construct the table containing all events.
@@ -495,7 +488,9 @@ class DL1DataReaderSTAGE1(DL1DataReader):
                         )
                         tel_tables = []
                         for tel_id in selected_telescopes[self.tel_type]:
-                            tel_table = tel_type_table[tel_type_table["tel_id"] == tel_id]
+                            tel_table = tel_type_table[
+                                tel_type_table["tel_id"] == tel_id
+                            ]
 
                             tel_table = join(
                                 left=tel_table,
@@ -550,16 +545,7 @@ class DL1DataReaderSTAGE1(DL1DataReader):
 
                 elif self.mode == "stereo":
 
-                    # Construct the table containing all events.
                     # The shower simulation table is joined with the subarray trigger table.
-                    simshower_table = read_table(f, "/simulation/event/subarray/shower")
-                    true_shower_primary_id = simshower_table["true_shower_primary_id"][
-                        0
-                    ]
-
-                    simshower_table.add_column(
-                        np.arange(len(simshower_table)), name="sim_index", index=0
-                    )
                     trigger_table = read_table(f, "/dl1/event/subarray/trigger")
                     allevents = join(
                         left=trigger_table,

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -450,6 +450,20 @@ class DL1DataReaderSTAGE1(DL1DataReader):
                 example_identifiers = []
                 if self.mode == "mono":
 
+                    simshower_table = read_table(
+                        f, "/simulation/event/subarray/shower"
+                    )
+
+                    true_shower_primary_id = simshower_table[
+                        "true_shower_primary_id"
+                    ][0]
+
+                    simshower_table.add_column(
+                        np.arange(len(simshower_table)),
+                        name="sim_index",
+                        index=0,
+                    )
+
                     if self.split_datasets_by == "tel_id":
                         # Construct the table containing all events.
                         # First, the telescope tables are joined with the shower simulation
@@ -462,17 +476,7 @@ class DL1DataReaderSTAGE1(DL1DataReader):
                             tel_table.add_column(
                                 np.arange(len(tel_table)), name="img_index", index=0
                             )
-                            simshower_table = read_table(
-                                f, "/simulation/event/subarray/shower"
-                            )
-                            true_shower_primary_id = simshower_table[
-                                "true_shower_primary_id"
-                            ][0]
-                            simshower_table.add_column(
-                                np.arange(len(simshower_table)),
-                                name="sim_index",
-                                index=0,
-                            )
+
                             tel_table = join(
                                 left=tel_table,
                                 right=simshower_table,
@@ -493,17 +497,6 @@ class DL1DataReaderSTAGE1(DL1DataReader):
                         for tel_id in selected_telescopes[self.tel_type]:
                             tel_table = tel_type_table[tel_type_table["tel_id"] == tel_id]
 
-                            simshower_table = read_table(
-                                f, "/simulation/event/subarray/shower"
-                            )
-                            true_shower_primary_id = simshower_table[
-                                "true_shower_primary_id"
-                            ][0]
-                            simshower_table.add_column(
-                                np.arange(len(simshower_table)),
-                                name="sim_index",
-                                index=0,
-                            )
                             tel_table = join(
                                 left=tel_table,
                                 right=simshower_table,

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -489,20 +489,28 @@ class DL1DataReaderSTAGE1(DL1DataReader):
                         tel_type_table.add_column(
                             np.arange(len(tel_type_table)), name="img_index", index=0
                         )
-                        simshower_table = read_table(
-                            f, "/simulation/event/subarray/shower"
-                        )
-                        true_shower_primary_id = simshower_table[
-                            "true_shower_primary_id"
-                        ][0]
-                        simshower_table.add_column(
-                            np.arange(len(simshower_table)), name="sim_index", index=0
-                        )
-                        allevents = join(
-                            left=tel_type_table,
-                            right=simshower_table,
-                            keys=["obs_id", "event_id"],
-                        )
+                        tel_tables = []
+                        for tel_id in selected_telescopes[self.tel_type]:
+                            tel_table = tel_type_table[tel_type_table["tel_id"] == tel_id]
+
+                            simshower_table = read_table(
+                                f, "/simulation/event/subarray/shower"
+                            )
+                            true_shower_primary_id = simshower_table[
+                                "true_shower_primary_id"
+                            ][0]
+                            simshower_table.add_column(
+                                np.arange(len(simshower_table)),
+                                name="sim_index",
+                                index=0,
+                            )
+                            tel_table = join(
+                                left=tel_table,
+                                right=simshower_table,
+                                keys=["obs_id", "event_id"],
+                            )
+                            tel_tables.append(tel_table)
+                        allevents = vstack(tel_tables)
 
                     # MC event selection based on the shower simulation table
                     # and image and parameter selection based on the parameter tables


### PR DESCRIPTION
The select tel id option was broken, when processing stage1 datasets `split by tel_type`. However, this is not affecting any published results, i.e. the ICRC results, because stage1 datasets `split by tel_id` were used. It is fixed now but we probably want to only support `split by tel_id` in prediction mode in the future.