### PR TITLE
upgrade to ctapipe v0.16.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -204,7 +204,7 @@ Links
 
 
 * `Cherenkov Telescope Array (CTA) <https://www.cta-observatory.org/>`_ - Homepage of the CTA collaboration 
-* `CTLearn <https://github.com/ctlearn-project/ctlearn/>`_ and `GammaLearn <https://gitlab.lapp.in2p3.fr/GammaLearn/GammaLearn>`_\ - Repository of code for studies on applying deep learning to IACT analysis tasks. Maintained by groups at Columbia University, Universidad Complutense de Madrid, Barnard College (CTLearn) and LAPP (GammaLearn).
+* `CTLearn <https://github.com/ctlearn-project/ctlearn/>`_ and `GammaLearn <https://gitlab.lapp.in2p3.fr/GammaLearn/GammaLearn>`_ - Repository of code for studies on applying deep learning to IACT analysis tasks. Maintained by groups at Columbia University, Universidad Complutense de Madrid, Barnard College (CTLearn) and LAPP (GammaLearn).
 * `ctapipe <https://cta-observatory.github.io/ctapipe/>`_ - Official documentation for the ctapipe analysis package (in development)
 * `ViTables <http://vitables.org/>`_ - Homepage for ViTables application for Pytables HDF5 file visualization
 

--- a/README.rst
+++ b/README.rst
@@ -190,14 +190,10 @@ All other scripts located in the scripts/deprecated directory are not currently 
 Examples/Tips
 -------------
 
-
-* Vitables is very helpful for viewing and debugging PyTables-style HDF5 files. Installation/download instructions can be found in the link below. NOTE: It is STRONGLY recommended that vitables be installed in a separate Anaconda environment with Python version 2.7 to avoid issues with conflicting PyQt5 versions. See this issue thread for details: `https://github.com/ContinuumIO/anaconda-issues/issues/1554 <https://github.com/ContinuumIO/anaconda-issues/issues/1554>`_
+* Vitables is very helpful for viewing and debugging PyTables-style HDF5 files. Installation/download instructions can be found in the link below.
 
 Known Issues/Troubleshooting
 ----------------------------
-
-
-* ViTables PyQt5 dependency confict (pip vs. conda): `relevent issue thread <https://github.com/ContinuumIO/anaconda-issues/issues/1554>`_
 
 Links
 -----

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ DL1 Data Handler
    :alt: Coverage Status
 
 
-A package of utilities for writing (deprecated), reading, and applying image processing to `Cherenkov Telescope Array (CTA) <https://www.cta-observatory.org/>`_\ DL1 data (calibrated images) in a standardized format. Created primarily for testing machine learning image analysis techniques on IACT data.
+A package of utilities for writing (deprecated), reading, and applying image processing to `Cherenkov Telescope Array (CTA) <https://www.cta-observatory.org/>`_ DL1 data (calibrated images) in a standardized format. Created primarily for testing machine learning image analysis techniques on IACT data.
 
 Currently supports data in the CTA pyhessio sim_telarray format, with the possibility of supporting other IACT data formats in the future. Built using ctapipe and PyTables.
 
@@ -55,7 +55,7 @@ necessary package channels, and install dl1-data-handler specified version and i
 
 .. code-block:: bash
 
-   DL1DH_VER=0.10.7
+   DL1DH_VER=0.10.8
    wget https://raw.githubusercontent.com/cta-observatory/dl1-data-handler/v$DL1DH_VER/environment.yml
    conda env create -n [ENVIRONMENT_NAME] -f environment.yml
    conda activate [ENVIRONMENT_NAME]
@@ -63,12 +63,12 @@ necessary package channels, and install dl1-data-handler specified version and i
 
 This should automatically install all dependencies (NOTE: this may take some time, as by default MKL is included as a dependency of NumPy and it is very large).
 
-If you want to import any functionality from dl1-data-handler into your own Python scripts, then you are all set. However, if you wish to make use of any of the scripts in dl1-data-handler/scripts (like write_data.py), you should also clone the repository locally and checkout the corresponding tag (i.e. for version v0.10.7): 
+If you want to import any functionality from dl1-data-handler into your own Python scripts, then you are all set. However, if you wish to make use of any of the scripts in dl1-data-handler/scripts (like write_data.py), you should also clone the repository locally and checkout the corresponding tag (i.e. for version v0.10.8): 
 
 .. code-block:: bash
 
    git clone https://github.com/cta-observatory/dl1-data-handler.git
-   git checkout v0.10.7
+   git checkout v0.10.8
 
 dl1-data-handler should already have been installed in your environment by Conda, so no further installation steps (i.e. with setuptools or pip) are necessary and you should be able to run scripts/write_data.py directly.
 
@@ -197,15 +197,14 @@ Known Issues/Troubleshooting
 ----------------------------
 
 
-* As of v0.7.2 there appears to be an issue when processing files containing SCT data. A fix is planned for a future version.
 * ViTables PyQt5 dependency confict (pip vs. conda): `relevent issue thread <https://github.com/ContinuumIO/anaconda-issues/issues/1554>`_
 
 Links
 -----
 
 
-* `Cherenkov Telescope Array (CTA) <https://www.cta-observatory.org/>`_\ - Homepage of the CTA collaboration 
-* `CTLearn <https://github.com/ctlearn-project/ctlearn/>`_\ and `GammaLearn <https://gitlab.lapp.in2p3.fr/GammaLearn/GammaLearn>`_\ - Repository of code for studies on applying deep learning to IACT analysis tasks. Maintained by groups at Columbia University, Universidad Complutense de Madrid, Barnard College (CTLearn) and LAPP (GammaLearn).
-* `ctapipe <https://cta-observatory.github.io/ctapipe/>`_\ - Official documentation for the ctapipe analysis package (in development)
-* `ViTables <http://vitables.org/>`_\ - Homepage for ViTables application for Pytables HDF5 file visualization
+* `Cherenkov Telescope Array (CTA) <https://www.cta-observatory.org/>`_ - Homepage of the CTA collaboration 
+* `CTLearn <https://github.com/ctlearn-project/ctlearn/>`_ and `GammaLearn <https://gitlab.lapp.in2p3.fr/GammaLearn/GammaLearn>`_\ - Repository of code for studies on applying deep learning to IACT analysis tasks. Maintained by groups at Columbia University, Universidad Complutense de Madrid, Barnard College (CTLearn) and LAPP (GammaLearn).
+* `ctapipe <https://cta-observatory.github.io/ctapipe/>`_ - Official documentation for the ctapipe analysis package (in development)
+* `ViTables <http://vitables.org/>`_ - Homepage for ViTables application for Pytables HDF5 file visualization
 

--- a/README.rst
+++ b/README.rst
@@ -78,9 +78,9 @@ Dependencies
 The main dependencies are:
 
 
-* PyTables >= 3.4.4
-* NumPy >= 1.15.0
-* ctapipe == 0.15.0
+* PyTables >= 3.7
+* NumPy >= 1.16.0
+* ctapipe == 0.16.0
 
 Also see setup.py.
 

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -434,9 +434,17 @@ class DL1DataReaderSTAGE1(DL1DataReader):
                 )
             )
 
-        self.telescopes = {}
         if selected_telescope_ids is None:
             selected_telescope_ids = []
+        (
+            self.telescopes,
+            self.selected_telescopes,
+            self.camera2index,
+        ) = self._construct_telescopes_selection(
+            self.files[first_file].root.configuration.instrument.subarray.layout,
+            selected_telescope_types,
+            selected_telescope_ids,
+        )
 
         if multiplicity_selection is None:
             multiplicity_selection = {}
@@ -512,15 +520,6 @@ class DL1DataReaderSTAGE1(DL1DataReader):
                     example_identifiers_file, key="/shower_primary_id_to_class"
                 ).to_dict("records")[0]
             self.num_classes = len(self.simulated_particles) - 1
-            (
-                self.telescopes,
-                self.selected_telescopes,
-                self.camera2index,
-            ) = self._construct_telescopes_selection(
-                self.files[first_file].root.configuration.instrument.subarray.layout,
-                selected_telescope_types,
-                selected_telescope_ids,
-            )
             example_identifiers_file.close()
         else:
 
@@ -531,7 +530,7 @@ class DL1DataReaderSTAGE1(DL1DataReader):
                     self.simulation_info = super()._construct_simulated_info(
                         f, self.simulation_info, file_type="stage1"
                     )
-                # Teslecope selection
+                # Telescope selection
                 (
                     telescopes,
                     selected_telescopes,
@@ -982,7 +981,6 @@ class DL1DataReaderSTAGE1(DL1DataReader):
                         "Inconsistent telescope definition in " "{}".format(filename)
                     )
                 self.selected_telescopes = selected_telescopes
-                self.camera2index = camera2index
 
                 if self.example_identifiers is None:
                     self.example_identifiers = example_identifiers
@@ -1087,6 +1085,7 @@ class DL1DataReaderSTAGE1(DL1DataReader):
             self.pixel_positions, self.num_pixels = self._construct_pixel_positions(
                 self.files[first_file].root.configuration.instrument.telescope
             )
+
             if "camera_types" not in mapping_settings:
                 mapping_settings["camera_types"] = self.pixel_positions.keys()
             self.image_mapper = ImageMapper(
@@ -1235,7 +1234,6 @@ class DL1DataReaderSTAGE1(DL1DataReader):
             ]
         else:
             cameras = self.camera2index.keys()
-
 
         pixel_positions = {}
         num_pixels = {}

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -634,13 +634,23 @@ class DL1DataReaderSTAGE1(DL1DataReader):
                     if parameter_selection:
                         for filter in parameter_selection:
                             if "min_value" in filter:
-                                allevents = allevents[
-                                    allevents[filter["col_name"]] >= filter["min_value"]
-                                ]
+                                if filter["col_name"] in allevents.colnames:
+                                    allevents = allevents[
+                                        allevents[filter["col_name"]] >= filter["min_value"]
+                                    ]
+                                else:
+                                    allevents = allevents[
+                                        allevents["camera_frame_"+filter["col_name"]] >= filter["min_value"]
+                                    ]
                             if "max_value" in filter:
-                                allevents = allevents[
-                                    allevents[filter["col_name"]] < filter["max_value"]
-                                ]
+                                if filter["col_name"] in allevents.colnames:
+                                    allevents = allevents[
+                                        allevents[filter["col_name"]] < filter["max_value"]
+                                    ]
+                                else:
+                                    allevents = allevents[
+                                        allevents["camera_frame_"+filter["col_name"]] < filter["max_value"]
+                                    ]
 
                     # TODO: Fix pointing over time (see ctapipe issue 1484 & 1562)
                     if self.pointing_mode in ["subarray", "divergent"]:
@@ -802,16 +812,27 @@ class DL1DataReaderSTAGE1(DL1DataReader):
                                 if parameter_selection:
                                     for filter in parameter_selection:
                                         if "min_value" in filter:
-                                            tel_table = tel_table[
-                                                tel_table[filter["col_name"]]
-                                                >= filter["min_value"]
-                                            ]
+                                            if filter["col_name"] in tel_table.colnames:
+                                                tel_table = tel_table[
+                                                    tel_table[filter["col_name"]]
+                                                    >= filter["min_value"]
+                                                ]
+                                            else:
+                                                tel_table = tel_table[
+                                                    tel_table["camera_frame_"+filter["col_name"]]
+                                                    >= filter["min_value"]
+                                                ]
                                         if "max_value" in filter:
-                                            tel_table = tel_table[
-                                                tel_table[filter["col_name"]]
-                                                < filter["max_value"]
-                                            ]
-
+                                            if filter["col_name"] in tel_table.colnames:
+                                                tel_table = tel_table[
+                                                    tel_table[filter["col_name"]]
+                                                    < filter["max_value"]
+                                                ]
+                                            else:
+                                                tel_table = tel_table[
+                                                    tel_table["camera_frame_"+filter["col_name"]]
+                                                    < filter["max_value"]
+                                                ]
                                 merged_table = join(
                                     left=tel_table,
                                     right=allevents[selected_events],

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: dl1_data_handler
-  version: "0.10.7"
+  version: "0.10.8"
 
 source:
   #path: ./
   git_url: https://github.com/cta-observatory/dl1-data-handler.git
-  git_rev: v0.10.7
+  git_rev: v0.10.8
 
 build:
   noarch: generic
@@ -13,25 +13,25 @@ build:
 
 requirements:
   build:
-    - python ==3.9
+    - python >=3.9
     - numpy >=1.15.0
     - jupyter
-    - ctapipe ==0.15.0
-    - pytables >=3.4.4 
+    - ctapipe ==0.16.0
+    - pytables >=3.7 
     - pandas
   host:
-    - python ==3.9
+    - python >=3.9
     - numpy >=1.15.0
     - jupyter
-    - ctapipe ==0.15.0
-    - pytables >=3.4.4
+    - ctapipe ==0.16.0
+    - pytables >=3.7
     - pandas
   run:
-    - python ==3.9
+    - python >=3.9
     - numpy >=1.15.0
     - jupyter
-    - ctapipe ==0.15.0
-    - pytables >=3.4.4
+    - ctapipe ==0.16.0
+    - pytables >=3.7
     - pandas
   test:
     imports:

--- a/setup.py
+++ b/setup.py
@@ -21,12 +21,12 @@ setup(
     install_requires=[
         "numpy>1.16",
         "astropy",
-        "ctapipe==0.15.0",
+        "ctapipe==0.16.0",
         "traitlets>=5.0",
         "jupyter",
         "pandas",
         "pytest-cov",
-        "tables",
+        "tables>=3.7",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
This PR upgrades dl1dh to be compatible with ctapipe v0.16.0 and the CTA data format v4.0.0. Since there is no full production available yet we still support CTA data formats v1.X, v2.X and v3.X for the time being. 