### PR TITLE
Fix versioning of cta data models

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ necessary package channels, and install dl1-data-handler specified version and i
 
 .. code-block:: bash
 
-   DL1DH_VER=0.10.8
+   DL1DH_VER=0.10.9
    wget https://raw.githubusercontent.com/cta-observatory/dl1-data-handler/v$DL1DH_VER/environment.yml
    conda env create -n [ENVIRONMENT_NAME] -f environment.yml
    conda activate [ENVIRONMENT_NAME]
@@ -63,12 +63,12 @@ necessary package channels, and install dl1-data-handler specified version and i
 
 This should automatically install all dependencies (NOTE: this may take some time, as by default MKL is included as a dependency of NumPy and it is very large).
 
-If you want to import any functionality from dl1-data-handler into your own Python scripts, then you are all set. However, if you wish to make use of any of the scripts in dl1-data-handler/scripts (like write_data.py), you should also clone the repository locally and checkout the corresponding tag (i.e. for version v0.10.8): 
+If you want to import any functionality from dl1-data-handler into your own Python scripts, then you are all set. However, if you wish to make use of any of the scripts in dl1-data-handler/scripts (like write_data.py), you should also clone the repository locally and checkout the corresponding tag (i.e. for version v0.10.9):
 
 .. code-block:: bash
 
    git clone https://github.com/cta-observatory/dl1-data-handler.git
-   git checkout v0.10.8
+   git checkout v0.10.9
 
 dl1-data-handler should already have been installed in your environment by Conda, so no further installation steps (i.e. with setuptools or pip) are necessary and you should be able to run scripts/write_data.py directly.
 
@@ -80,7 +80,7 @@ The main dependencies are:
 
 * PyTables >= 3.7
 * NumPy >= 1.16.0
-* ctapipe == 0.16.0
+* ctapipe == 0.17.0
 
 Also see setup.py.
 

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -264,7 +264,7 @@ class DL1DataReader:
             simulation_table = file.root.configuration.simulation
             runs = simulation_table._f_get_child("run")
             shower_reuse = max(np.array(runs.cols._f_col("shower_reuse")))
-            if self.data_model_version.startswith("v4"):
+            if self.data_model_mainversion >= 4:
                 n_showers = sum(np.array(runs.cols._f_col("n_showers"))) * shower_reuse
             else:
                 n_showers = sum(np.array(runs.cols._f_col("num_showers"))) * shower_reuse
@@ -416,6 +416,7 @@ class DL1DataReaderSTAGE1(DL1DataReader):
 
         first_file = list(self.files)[0]
         self.data_model_version = self._v_attrs["CTA PRODUCT DATA MODEL VERSION"]
+        self.data_model_mainversion = int(self.data_model_version.split(".")[0].replace("v",""))
         self.process_type = self._v_attrs["CTA PROCESS TYPE"]
         self.instrument_id = self._v_attrs["CTA INSTRUMENT ID"]
 
@@ -1179,7 +1180,7 @@ class DL1DataReaderSTAGE1(DL1DataReader):
             tel_type = row["tel_description"].decode()
             if tel_type not in telescopes:
                 telescopes[tel_type] = []
-            if not self.data_model_version.startswith("v1"):
+            if self.data_model_mainversion > 1:
                 camera_index = row["camera_index"]
                 if self._get_camera_type(tel_type) not in camera2index:
                     camera2index[self._get_camera_type(tel_type)] = camera_index
@@ -1224,8 +1225,7 @@ class DL1DataReaderSTAGE1(DL1DataReader):
         num_pixels (dict): dictionary of `{cameras: num_pixels}`
 
         """
-
-        if not self.data_model_version.startswith("v4"):
+        if self.data_model_mainversion < 4:
             cameras = [
                 description.decode("UTF-8").split("_")[-1]
                 for description in telescope_type_information.optics.cols._f_col(

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     install_requires=[
         "numpy>1.16",
         "astropy",
-        "ctapipe==0.16.0",
+        "ctapipe==0.17.0",
         "traitlets>=5.0",
         "jupyter",
         "pandas",


### PR DESCRIPTION
This is a minor bug fix about tracking the correct version of the CTA data model. At some point, we only want to support the latest one rather than all versions as it is for the time being. The PR also upgrades ctapipe to the latest version v0.17.