### PR TITLE
Add LST-SiPM camera

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ The main dependencies are:
 
 * PyTables >= 3.7
 * NumPy >= 1.16.0
-* ctapipe == 0.17.0
+* ctapipe == 0.19.0
 
 Also see setup.py.
 

--- a/dl1_data_handler/image_mapper.py
+++ b/dl1_data_handler/image_mapper.py
@@ -26,6 +26,7 @@ class ImageMapper:
         # when multiple instances of ImageMapper are created
         self.image_shapes = {
             "LSTCam": (110, 110, 1),
+            "LSTSiPMCam": (234, 234, 1),
             "FlashCam": (112, 112, 1),
             "NectarCam": (110, 110, 1),
             "SCTCam": (120, 120, 1),

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -1252,10 +1252,12 @@ class DL1DataReaderSTAGE1(DL1DataReader):
             pixel_positions[camera] = np.stack((pix_x, pix_y))
             # For now hardcoded, since this information is not in the h5 files.
             # The official CTA DL1 format will contain this information.
-            if camera in ["LSTCam", "NectarCam", "MAGICCam"]:
+            if camera in ["LSTCam", "LSTSiPMCam", "NectarCam", "MAGICCam"]:
                 rotation_angle = -70.9 * np.pi / 180.0
                 if camera == "MAGICCam":
                     rotation_angle = -100.893 * np.pi / 180.0
+                if camera == "LSTSiPMCam":
+                    rotation_angle = -cam_geom._v_attrs["PIX_ROT"] * np.pi / 180.0
                 if self.process_type == "Observation" and camera == "LSTCam":
                     rotation_angle = -70.8935 * np.pi / 180.0
                 rotation_matrix = np.matrix(

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
     - astropy
     - numpy
     - pip
-    - ctapipe==0.15.0
+    - ctapipe==0.19.0
     - traitlets>=5.0
     - pyyaml
     - pandas

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     install_requires=[
         "numpy>1.16",
         "astropy",
-        "ctapipe==0.17.0",
+        "ctapipe==0.19",
         "traitlets>=5.0",
         "jupyter",
         "pandas",


### PR DESCRIPTION
This PR adds the LST-SiPM camera to the ImageMapper (see cool showers attached). Also, we upgrade to ctapipe v0.19.

Raw DL1 gamma event:
![LSTSiPM_Gamma_raw](https://user-images.githubusercontent.com/37835610/233694207-ecf65685-17c4-4a58-b3e0-ea9558455cd3.png)
Cleaned DL1 gamma event:
![LSTSiPM_Gamma_cleaned](https://user-images.githubusercontent.com/37835610/233694201-8ea3cffa-9b57-40c2-af9f-64071b9eb1b3.png)

Raw DL1 proton event:
![LSTSiPM_Proton_raw](https://user-images.githubusercontent.com/37835610/233694573-5b1b6a12-a221-4ae2-80a8-3c8ddbb9781f.png)
Cleaned DL1 proton event:
![LSTSiPM_Proton_cleaned](https://user-images.githubusercontent.com/37835610/233694571-82661e40-9c45-4487-a661-8e35c5c9e9c4.png)

Nice event (proton with a muon ring):
![ProtonWithMuon_LSTSiPM_oversampling](https://user-images.githubusercontent.com/37835610/233694702-3a185c77-d023-455e-b3bc-e97f1b050132.png)


