### PR TITLE
Fix error from unneeded memory use

### DIFF
--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -268,12 +268,6 @@ class DL1DataReader:
                 n_showers = sum(np.array(runs.cols._f_col("n_showers"))) * shower_reuse
             else:
                 n_showers = sum(np.array(runs.cols._f_col("num_showers"))) * shower_reuse
-            if "service" in file.root.simulation:
-                service_table = file.root.simulation.service
-                shower_distributions = service_table._f_get_child("shower_distribution")
-                num_showers = np.sum(
-                    np.array(shower_distributions.cols._f_col("histogram"))
-                )
             energy_range_min = min(np.array(runs.cols._f_col("energy_range_min")))
             energy_range_max = max(np.array(runs.cols._f_col("energy_range_max")))
             max_scatter_range = max(np.array(runs.cols._f_col("max_scatter_range")))


### PR DESCRIPTION
Initializing a DL1DataReaderSTAGE1 on my machine results in a crash with the following error message:

MemoryError: Unable to allocate 23.4 GiB for an array with shape (262144, 120, 200) and data type float32

The cause is a few lines that are computing num_showers using shower histograms in the simulation files. In fact, num_showers is never subsequently used in reader.py (n_showers is used instead). Deleting these lines solves the error.