### PR TITLE
Fix telescope indexing assumption

### DIFF
--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -732,7 +732,7 @@ class DL1DataReaderSTAGE1(DL1DataReader):
                     if len(selected_telescopes) > 1:
                         # Get all tel ids from the subarray
                         selection_mask = np.zeros_like(tels_with_trigger)
-                        tel_ids = selected_telescopes.values()
+                        tel_ids = np.array(selected_telescopes.values())
                         for tel_id in tel_ids:
                             selection_mask[:, tel_id_to_trigger_idx[tel_id]] = 1
                         # Construct the telescope trigger information restricted to allowed telescopes
@@ -753,7 +753,7 @@ class DL1DataReaderSTAGE1(DL1DataReader):
                     for tel_type in selected_telescopes:
                         # Get all selected tel ids of this telescope type
                         selection_mask = np.zeros_like(tels_with_trigger)
-                        tel_ids = selected_telescopes[tel_type]
+                        tel_ids = np.array(selected_telescopes[tel_type])
                         for tel_id in tel_ids:
                             selection_mask[:, tel_id_to_trigger_idx[tel_id]] = 1
                         # Construct the telescope trigger information restricted to allowed telescopes of this telescope type


### PR DESCRIPTION
In the CTAO dataset (https://zenodo.org/record/7298569), tel_ids do not follow strict sequential ordering. Of the 13 telescopes, the last two have tel_ids 35 and 19. In several places in DL1DataReader, the assumption is made that tel_ids are strictly sequential, which is incorrect in this case and breaks when loading MST data. This commit fixes this broken assumption by instead explicitly using the tel_ids in the order specified in the subarray layout table.