### PR TITLE
Data reading of the AI-based trigger system

### DIFF
--- a/dl1_data_handler/image_mapper.py
+++ b/dl1_data_handler/image_mapper.py
@@ -968,6 +968,21 @@ class ImageMapper:
             output_grid = np.column_stack([x_grid, y_grid])
 
         else:
+            if camera_type == "LSTCam":
+                # Additional smoothing of the 'y_ticks' array for LSTCam pixel positions.
+                num_y_ticks = len(y_ticks)
+                remove_y_val = []
+                change_y_val = []
+                for i in np.arange(num_y_ticks - 1):
+                    if np.abs(y_ticks[i] - y_ticks[i + 1]) <= 0.002:
+                        remove_y_val.append(y_ticks[i])
+                        change_y_val.append(y_ticks[i + 1])
+                for j in np.arange(len(remove_y_val)):
+                    y_ticks.remove(remove_y_val[j])
+                    for k in np.arange(len(y)):
+                        if y[k] == remove_y_val[j]:
+                            y[k] = change_y_val[j]
+
             if len(x_ticks) < len(y_ticks):
                 first_ticks = x_ticks
                 first_pos = x

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -461,7 +461,10 @@ class DL1DataReader:
         ):
             return vector
 
-        return self.image_mapper.map_image(vector, self._get_camera_type(tel_type))
+        image = self.image_mapper.map_image(vector, self._get_camera_type(tel_type))
+        if self.process_type == "Observation" and self._get_camera_type(tel_type) == "LSTCam":
+            image = np.transpose(np.flip(image, axis=(0, 1)), (1,0,2)) # x = -y & y = -x
+        return image
 
     def _append_subarray_info(self, subarray_table, subarray_info, query):
         with lock:

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -673,8 +673,8 @@ class DL1DataReaderSTAGE1(DL1DataReader):
                 ).to_dict("records")[0]
             self.num_classes = len(self.simulated_particles) - 1
             if self.include_nsb_patches:
-                self._nsb_prob = np.around(1/self.num_classes, decimals=2)
-                self._shower_prob = np.around(1-self._nsb_prob, decimals=2)
+                self._nsb_prob = np.around(1 / self.num_classes, decimals=2)
+                self._shower_prob = np.around(1 - self._nsb_prob, decimals=2)
             example_identifiers_file.close()
         else:
             for file_idx, (filename, f) in enumerate(self.files.items()):
@@ -1164,8 +1164,8 @@ class DL1DataReaderSTAGE1(DL1DataReader):
                         self.simulated_particles["total"] / (self.num_classes + 1)
                     )
                     self.num_classes += 1
-                    self._nsb_prob = np.around(1/self.num_classes, decimals=2)
-                    self._shower_prob = np.around(1-self._nsb_prob, decimals=2)
+                    self._nsb_prob = np.around(1 / self.num_classes, decimals=2)
+                    self._shower_prob = np.around(1 - self._nsb_prob, decimals=2)
 
                 if (
                     len(self.simulated_particles) > 2
@@ -2067,7 +2067,9 @@ class DL1DataReaderSTAGE1(DL1DataReader):
             if self.process_type == "Simulation":
                 nrow, index, tel_id = identifiers[1:4]
                 if self.include_nsb_patches:
-                    random_trigger_patch = np.random.choice([False, True], p=[self._shower_prob, self._nsb_prob])
+                    random_trigger_patch = np.random.choice(
+                        [False, True], p=[self._shower_prob, self._nsb_prob]
+                    )
             else:
                 index, tel_id = identifiers[1:3]
 
@@ -2304,7 +2306,9 @@ class DL1DataReaderSTAGE1(DL1DataReader):
                 nrow = identifiers[1]
                 trigger_info = identifiers[2]
                 if self.include_nsb_patches:
-                    random_trigger_patch = np.random.choice([False, True], p=[self._shower_prob, self._nsb_prob])
+                    random_trigger_patch = np.random.choice(
+                        [False, True], p=[self._shower_prob, self._nsb_prob]
+                    )
                 if self.pointing_mode == "divergent":
                     pointing_info = identifiers[3]
             else:
@@ -2345,7 +2349,7 @@ class DL1DataReaderSTAGE1(DL1DataReader):
                 events = self.files[filename].root.simulation.event.subarray.shower
                 for column in self.event_info:
                     dtype = events.cols._f_col(column).dtype
-                    if random_trigger_patch and column=="true_shower_primary_id":
+                    if random_trigger_patch and column == "true_shower_primary_id":
                         example.append(np.array(404, dtype=dtype))
                     else:
                         example.append(np.array(events[nrow][column], dtype=dtype))

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -1781,13 +1781,11 @@ class DL1DataReaderSTAGE1(DL1DataReader):
             # For now hardcoded, since this information is not in the h5 files.
             # The official CTA DL1 format will contain this information.
             if camera in ["LSTCam", "LSTSiPMCam", "NectarCam", "MAGICCam"]:
-                rotation_angle = -70.9 * np.pi / 180.0
+                rotation_angle = -cam_geom._v_attrs["PIX_ROT"] * np.pi / 180.0
                 if camera == "MAGICCam":
                     rotation_angle = -100.893 * np.pi / 180.0
-                if camera == "LSTSiPMCam":
-                    rotation_angle = -cam_geom._v_attrs["PIX_ROT"] * np.pi / 180.0
                 if self.process_type == "Observation" and camera == "LSTCam":
-                    rotation_angle = -70.8935 * np.pi / 180.0
+                    rotation_angle = -40.89299998552154 * np.pi / 180.0
                 rotation_matrix = np.matrix(
                     [
                         [np.cos(rotation_angle), -np.sin(rotation_angle)],

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -589,6 +589,7 @@ class DL1DataReaderSTAGE1(DL1DataReader):
                     .shape[-1]
                 )
                 self.waveform_r0pedsub = False
+                self.waveform_FADC_offset = None
             self.waveform_sequence_length = waveform_settings[
                 "waveform_sequence_length"
             ]

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -432,7 +432,7 @@ class DL1DataReader:
         )
         # If the telescope didn't trigger, the image index is -1 and a blank
         # image of all zeros with be loaded
-        if image_index != -1 and child:
+        if image_index != -1 and child is not None:
             with lock:
                 record = child[image_index]
                 for i, channel in enumerate(self.image_channels):
@@ -1394,7 +1394,7 @@ class DL1DataReaderSTAGE1(DL1DataReader):
 
         # Retrieve the DL1 cleaning mask if the child of the DL1 images are provided
         dl1_cleaning_mask = None
-        if waveform_index != -1 and img_child:
+        if waveform_index != -1 and img_child is not None:
             with lock:
                 dl1_cleaning_mask = np.array(
                     img_child[waveform_index]["image_mask"], dtype=int
@@ -1402,7 +1402,7 @@ class DL1DataReaderSTAGE1(DL1DataReader):
 
         # Retrieve the true image if the child of the simulated images are provided
         true_image, trigger_patch_true_image_sum = None, None
-        if waveform_index != -1 and sim_child:
+        if waveform_index != -1 and self.aitrigger:
             with lock:
                 true_image = np.expand_dims(
                     np.array(sim_child[waveform_index]["true_image"], dtype=int), axis=1
@@ -1410,7 +1410,7 @@ class DL1DataReaderSTAGE1(DL1DataReader):
 
         # If the telescope didn't trigger, the waveform index is -1 and a blank
         # waveform of all zeros with be loaded
-        if waveform_index != -1 and child:
+        if waveform_index != -1 and child is not None:
             with lock:
                 vector = child[waveform_index]["waveform"]
             if self.waveform_type is not None:
@@ -1479,7 +1479,7 @@ class DL1DataReaderSTAGE1(DL1DataReader):
                 vector, self._get_camera_type(tel_type)
             )
 
-            if sim_child:
+            if self.trigger_settings is not None:
                 trigger_patch_center = {}
                 waveform_shape_x = self.waveform_shapes[
                     self._get_camera_type(tel_type)
@@ -1740,10 +1740,7 @@ class DL1DataReaderSTAGE1(DL1DataReader):
                                             tel_table
                                         )
                                 sim_child = None
-                                if (
-                                    self.aitrigger
-                                    and "simulation" in self.files[filename].root
-                                ):
+                                if self.aitrigger and self.process_type == "Simulation":
                                     if (
                                         "images"
                                         in self.files[
@@ -1882,7 +1879,7 @@ class DL1DataReaderSTAGE1(DL1DataReader):
                                     tel_table
                                 )
                         sim_child = None
-                        if self.aitrigger and "simulation" in self.files[filename].root:
+                        if self.aitrigger and self.process_type == "Simulation":
                             if (
                                 "images"
                                 in self.files[filename].root.simulation.event.telescope
@@ -2011,7 +2008,7 @@ class DL1DataReaderSTAGE1(DL1DataReader):
                             sim_child = None
                             if (
                                 self.trigger_settings is not None
-                                and "simulation" in self.files[filename].root
+                                and self.process_type == "Simulation"
                             ):
                                 if (
                                     "images"

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -1562,6 +1562,8 @@ class DL1DataReaderSTAGE1(DL1DataReader):
             mapped_waveform = self.image_mapper.map_image(
                 vector, self._get_camera_type(tel_type)
             )
+            if self.process_type == "Observation" and self._get_camera_type(tel_type) == "LSTCam":
+                mapped_waveform = np.transpose(np.flip(mapped_waveform, axis=(0, 1)), (1,0,2)) # x = -y & y = -x
 
             if self.trigger_settings is not None:
                 trigger_patch_center = {}

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -576,6 +576,9 @@ class DL1DataReaderSTAGE1(DL1DataReader):
                     .shape[-1]
                 )
                 self.waveform_r0pedsub = waveform_settings["waveform_r0pedsub"]
+                self.waveform_FADC_offset = None
+                if "waveform_FADC_offset" in waveform_settings:
+                    self.waveform_FADC_offset = waveform_settings["waveform_FADC_offset"]
             if "calibrate" in self.waveform_type:
                 self.waveform_sequence_max_length = (
                     self.files[first_file]
@@ -1358,7 +1361,6 @@ class DL1DataReaderSTAGE1(DL1DataReader):
                                 ]
                             ]
                         )
-
             if self.image_channels is not None:
                 for camera_type in mapping_settings["camera_types"]:
                     self.image_mapper.image_shapes[camera_type] = (
@@ -1499,8 +1501,11 @@ class DL1DataReaderSTAGE1(DL1DataReader):
                 )
 
             # Retrieve the sequence around the shower maximum and calculate the pedestal
-            # level per pixel outside that sequence if R0-pedsub is selected
+            # level per pixel outside that sequence if R0-pedsub is selected and FADC
+            # offset is not provided from the simulation.
             pixped_nsb, nsb_sequence_length = None, None
+            if self.waveform_FADC_offset is not None:
+                pixped_nsb = np.full((vector.shape[0],), self.waveform_FADC_offset, dtype=int)
             if (
                 self.waveform_sequence_max_length - self.waveform_sequence_length
             ) < 0.001:

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -466,7 +466,7 @@ class DL1DataReaderSTAGE1(DL1DataReader):
         waveform_settings=None,
         image_settings=None,
         mapping_settings=None,
-        parameter_list=None,
+        parameter_settings=None,
         subarray_info=None,
         event_info=None,
         transforms=None,
@@ -560,7 +560,9 @@ class DL1DataReaderSTAGE1(DL1DataReader):
         self.image_scale = None
         self.peak_time_scale = None
         # Image parameters (DL1b)
-        self.parameter_list = parameter_list
+        self.parameter_list = None
+        if parameter_settings is not None:
+            self.parameter_list = parameter_settings["parameter_list"]
 
         # Get stage1 split_datasets_by type
         self.split_datasets_by = "tel_id"
@@ -1920,7 +1922,7 @@ class DL1DataReaderDL1DH(DL1DataReader):
         seed=None,
         image_settings=None,
         mapping_settings=None,
-        parameter_list=None,
+        parameter_settings=None,
         subarray_info=None,
         event_info=None,
         transforms=None,
@@ -2303,7 +2305,9 @@ class DL1DataReaderDL1DH(DL1DataReader):
                 )
 
         # Image parameters (DL1b)
-        self.parameter_list = parameter_list
+        self.parameter_list = None
+        if parameter_settings is not None:
+            self.parameter_list = parameter_settings["parameter_list"]
 
         super()._construct_unprocessed_example_description(
             self.files[first_file].root.Array_Information,

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     install_requires=[
         "numpy>1.16",
         "astropy",
-        "ctapipe==0.19",
+        "ctapipe==0.20",
         "traitlets>=5.0",
         "jupyter",
         "pandas",


### PR DESCRIPTION
This PR suggests the data reading of the AI-based trigger system primarily designed for the SiPM-based LST cameras. It enables the ability to crop "trigger patches" with configurable positions and sizes, and retrieve the total number of Cherenkov photons (from the simulated true image) of that given patch. A fraction of NSB patches with no (or truncated) Cherenkov signal can be included by randomly selecting a trigger patch. With CTLearn, the user can then design a CNN-based model to reconstruct the number of Cherenkov photons in the trigger patch as a regression problem. This would allow us to make the trigger decision with different observation-dependent thresholds after the reconstruction. 