### PR TITLE
Allowing external algo to find trigger patch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ necessary package channels, and install dl1-data-handler specified version and i
 
 .. code-block:: bash
 
-   DL1DH_VER=0.11.1
+   DL1DH_VER=0.12.0
    wget https://raw.githubusercontent.com/cta-observatory/dl1-data-handler/v$DL1DH_VER/environment.yml
    conda env create -n [ENVIRONMENT_NAME] -f environment.yml
    conda activate [ENVIRONMENT_NAME]
@@ -51,12 +51,12 @@ necessary package channels, and install dl1-data-handler specified version and i
 
 This should automatically install all dependencies (NOTE: this may take some time, as by default MKL is included as a dependency of NumPy and it is very large).
 
-If you want to import any functionality from dl1-data-handler into your own Python scripts, then you are all set. However, if you wish to make use of any of the scripts in dl1-data-handler/scripts (like write_data.py), you should also clone the repository locally and checkout the corresponding tag (i.e. for version v0.11.1):
+If you want to import any functionality from dl1-data-handler into your own Python scripts, then you are all set. However, if you wish to make use of any of the scripts in dl1-data-handler/scripts (like write_data.py), you should also clone the repository locally and checkout the corresponding tag (i.e. for version v0.12.0):
 
 .. code-block:: bash
 
    git clone https://github.com/cta-observatory/dl1-data-handler.git
-   git checkout v0.11.1
+   git checkout v0.12.0
 
 dl1-data-handler should already have been installed in your environment by Conda, so no further installation steps (i.e. with setuptools or pip) are necessary and you should be able to run scripts/write_data.py directly.
 

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ The main dependencies are:
 
 * PyTables >= 3.8
 * NumPy >= 1.20.0
-* ctapipe == 0.21.1
+* ctapipe == 0.21.2
 
 Also see setup.py.
 

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -129,6 +129,7 @@ class DLDataReader:
         # Telescope pointings
         self.telescope_pointings = {}
         self.fix_pointing_alt, self.fix_pointing_az = None, None
+        tel_id = None
         if self.process_type == "Observation":
             for tel_id in self.tel_ids:
                 with lock:

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -97,7 +97,7 @@ class DLDataReader:
             self.mode = mode
         else:
             raise ValueError(
-                f"Invalid mode selection '{mode}'. Valid options: " "'mono', 'stereo'"
+                f"Invalid mode selection '{mode}'. Valid options: 'mono', 'stereo'"
             )
 
         if subarray_info is None:
@@ -1849,7 +1849,7 @@ class DLDataReader:
                 index, tel_id = identifiers[1:3]
 
             trg_pixel_id, trg_waveform_sample_id = None, None
-            if self.trigger_settings is not None and self.get_trigger_patch == "file"
+            if self.trigger_settings is not None and self.get_trigger_patch == "file":
                 trg_pixel_id, trg_waveform_sample_id = identifiers[-2:]
 
             example = []

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         "numpy>=1.20",
         "scipy>=1.11",
         "astropy",
-        "ctapipe==0.21.1",
+        "ctapipe==0.21.2",
         "traitlets>=5.0",
         "jupyter",
         "pandas",


### PR DESCRIPTION
This PR allows to interface with an external algo (i.e. DBScan) to find the trigger patch. Information must be written into a `csv` file containing the `event_id`, `obs_id`, `tel_id`, `trg_pixel_id` (location; where the trigger happen via pixel_id), and `trg_waveform_sample_id` (time; at which waveform sample the trigger happen). The csv files have to be located at the same directory as the input data with the same naming convention ending with '`npe.csv`' instead of the standard `r0.dl1.h5`. The option to find the trigger patches from the true image or the integrated waveform is still possible.