### PR TITLE
example_identifiers_file is not able to open due a permissions issue.

### DIFF
--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -276,7 +276,7 @@ class DLDataReader:
         if example_identifiers_file is None:
             example_identifiers_file = {}
         else:
-            example_identifiers_file = pd.HDFStore(example_identifiers_file)
+            example_identifiers_file = pd.HDFStore(example_identifiers_file, mode='r')
 
         if "/example_identifiers" in list(example_identifiers_file.keys()):
             self.example_identifiers = pd.read_hdf(


### PR DESCRIPTION
example_identifiers_file fails to open due permissions issues.
For example:  

-rw-r--r-- 1 tjark.miener ctan-onsite-it 86051602 May 21 09:02 /fefs/aswg/workspace/tjark.miener/DeepCrab/logs/theta_16.087_az_108.090/LST1_cleanedTRN_type_fixcamgeo/example_identifiers_file.h5.

Opening in read mode I am able to open and read it without problems

