### PR TITLE
Removal of pandas dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,7 @@
 # conda env create -f environment.yml
 name: dl1dh
 channels:
-    - anaconda
     - conda-forge
-    - cta-observatory
 dependencies:
     - python>=3.10
     - astropy
@@ -14,6 +12,5 @@ dependencies:
     - ctapipe==0.23.2
     - traitlets
     - pyyaml
-    - pandas
     - pip:
         - pydot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     "ctapipe==0.23.2",
     "astropy",
     "numpy",
-    "pandas",
     "pip",
     "pyyaml",
     "scipy",


### PR DESCRIPTION
This PR removes `pandas` dependency and only uses `conda-forge` as the anaconda channel.