### PR TITLE
Adopt ctapipe coordinate frames

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ DL1 Data Handler
     :target: https://github.com/cta-observatory/dl1-data-handler/actions/workflows/python-package-conda.yml
     :alt: Continuos Integration
 
-A package of utilities for reading, and applying image processing to `Cherenkov Telescope Array (CTA) <https://www.ctao.org/>`_ R0/R1/DL0/DL1 data in a standardized format. Created primarily for testing machine learning image analysis techniques on IACT data.
+A package of utilities for reading, and applying image processing to `Cherenkov Telescope Array Observatory (CTAO) <https://www.ctao.org/>`_ R1/DL0/DL1 data in a standardized format. Created primarily for testing machine learning image analysis techniques on IACT data.
 
 Currently supports ctapipe v6.0.0 data format. 
 
@@ -43,7 +43,7 @@ necessary package channels, and install dl1-data-handler specified version and i
 
 .. code-block:: bash
 
-   DL1DH_VER=0.13.0
+   DL1DH_VER=0.14.0
    wget https://raw.githubusercontent.com/cta-observatory/dl1-data-handler/v$DL1DH_VER/environment.yml
    conda env create -n [ENVIRONMENT_NAME] -f environment.yml
    conda activate [ENVIRONMENT_NAME]
@@ -57,6 +57,6 @@ Links
 
 
 * `Cherenkov Telescope Array (CTA) <https://www.ctao.org/>`_ - Homepage of the CTA Observatory 
-* `CTLearn <https://github.com/ctlearn-project/ctlearn/>`_ and `GammaLearn <https://gitlab.lapp.in2p3.fr/GammaLearn/GammaLearn>`_ - Repository of code for studies on applying deep learning to IACT analysis tasks. Maintained by groups at Columbia University, Universidad Complutense de Madrid, Barnard College (CTLearn) and LAPP (GammaLearn).
+* `CTLearn <https://github.com/ctlearn-project/ctlearn/>`_ and `GammaLearn <https://gitlab.lapp.in2p3.fr/GammaLearn/GammaLearn>`_ - Repository of code for studies on applying deep learning to IACT analysis tasks. Maintained by groups at Universidad Complutense de Madrid, University of Geneva (CTLearn) and LAPP (GammaLearn).
 * `ctapipe <https://cta-observatory.github.io/ctapipe/>`_ - Official documentation for the ctapipe analysis package (in development)
 

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -842,10 +842,8 @@ class DLDataReader(Component):
         table = join(
             left=table,
             right=tel_tables,
-            keys=["obs_id", "event_id", "tel_id"],
+            keys=["obs_id", "tel_id"],
         )
-        # TODO: use keep_order for astropy v7.0.0
-        table.sort(["obs_id", "event_id", "tel_id"])
         return table
 
     def _transform_to_sky_spher_offsets(self, table) -> Table:

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -853,8 +853,8 @@ class DLDataReader(Component):
             location=self.subarray.reference_location,
             obstime=LST_EPOCH,
         )
-        sky_offset = fix_pointing.spherical_offsets_to(true_direction)
-        angular_separation = fix_pointing.separation(true_direction)
+        sky_offset = fix_array_pointing.spherical_offsets_to(true_direction)
+        angular_separation = fix_array_pointing.separation(true_direction)
         table.add_column(sky_offset[0], name="sky_offset_lon")
         table.add_column(sky_offset[1], name="sky_offset_lat")
         table.add_column(angular_separation, name="sky_angular_separation")

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -580,6 +580,10 @@ class DLDataReader(Component):
             # Read the trigger table.
             trigger_table = read_table(f, "/dl1/event/subarray/trigger")
             if self.process_type == ProcessType.Simulation:
+                # Read simulation information for each observation
+                simulation_info_table = read_table(f, "/configuration/simulation/run")
+                # Append the simulation information to the list of simulation information
+                simulation_info.append(simulation_info_table)
                 # Construct the shower simulation table
                 simshower_table = read_table(f, "/simulation/event/subarray/shower")
                 # The shower simulation table is joined with the subarray trigger table.
@@ -661,10 +665,6 @@ class DLDataReader(Component):
                 events.add_column(
                     true_shower_primary_class, name="true_shower_primary_class"
                 )
-                # Read simulation information for each observation
-                simulation_info_table = read_table(f, "/configuration/simulation/run")
-                # Append the simulation information to the list of simulation information
-                simulation_info.append(simulation_info_table)
                 array_pointing = self._get_array_pointing(f)
                 # Join the prediction table with the telescope pointing table
                 events = join(

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -699,10 +699,10 @@ class DLDataReader(Component):
 
     def get_tel_pointing(self, file, tel_id) -> Table:
         """
-        Retrieve the telescope pointing information for the specified telescope IDs.
+        Retrieve the telescope pointing information for the specified telescope ID.
 
         This method extracts the pointing information (azimuth and altitude)
-        for the given telescope IDs from the provided file.
+        for the given telescope ID from the provided file.
 
         Parameters:
         -----------
@@ -714,7 +714,8 @@ class DLDataReader(Component):
         Returns:
         --------
         tel_pointing : astropy.table.Table
-            A table containing pointing information (azimuth and altitude) for each telescope.
+            A table containing pointing information (azimuth and altitude)
+            for the specified telescope ID.
         """
         with lock:
             tel_pointing = read_table(

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -405,7 +405,7 @@ class DLDataReader(Component):
                 f"/dl1/event/telescope/parameters/tel_{self.tel_ids[0]:03d}",
             ).colnames
 
-        # Columns to keep in the the example identifiers
+        # Columns to keep in the example identifiers
         # This are the basic columns one need to do a
         # conventional IACT analysis with CNNs
         self.example_ids_keep_columns = ["table_index", "obs_id", "event_id", "tel_id"]
@@ -570,9 +570,7 @@ class DLDataReader(Component):
         (triggered and passed quality cuts) in the event. These identifiers are used to uniquely
         reference each example in the dataset.
         """
-        # Columns to keep in the the example identifiers
-        # This are the basic columns one need to do a
-        # conventional IACT analysis with CNNs
+        # Extend the columns to keep in the example identifiers
         self.example_ids_keep_columns.extend(["hillas_intensity"])
         simulation_info = []
         example_identifiers = []

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -502,7 +502,7 @@ class DLDataReader(Component):
                     keys=["obs_id", "tel_id"],
                 )
                 events = self._transform_to_cam_coord_offsets(events)
-                array_pointing = self._get_array_pointing(f)
+                array_pointing = self.get_array_pointing(f)
                 # Join the prediction table with the telescope pointing table
                 events = join(
                     left=events,
@@ -665,7 +665,7 @@ class DLDataReader(Component):
                 events.add_column(
                     true_shower_primary_class, name="true_shower_primary_class"
                 )
-                array_pointing = self._get_array_pointing(f)
+                array_pointing = self.get_array_pointing(f)
                 # Join the prediction table with the telescope pointing table
                 events = join(
                     left=events,
@@ -797,16 +797,6 @@ class DLDataReader(Component):
         tel_tables = []
         for tel_id in self.tel_ids:
             tel_table = table.copy()
-            tel_table.keep_columns(
-                [
-                    "obs_id",
-                    "tel_id",
-                    "true_alt",
-                    "true_az",
-                    "telescope_pointing_azimuth",
-                    "telescope_pointing_altitude",
-                ]
-            )
             tel_table = tel_table[tel_table["tel_id"] == tel_id]
             # Set the telescope pointing of the SkyOffsetSeparation tranform to the fix pointing
             tel_ground_frame = self.subarray.tel_coords[
@@ -834,6 +824,7 @@ class DLDataReader(Component):
             true_cam_distance = np.sqrt(
                 true_cam_position.x**2 + true_cam_position.y**2
             )
+            tel_table.keep_columns(["obs_id", "tel_id"])
             tel_table.add_column(true_cam_position.x, name="cam_coord_offset_x")
             tel_table.add_column(true_cam_position.y, name="cam_coord_offset_y")
             tel_table.add_column(true_cam_distance, name="cam_coord_distance")

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -140,8 +140,8 @@ class DLDataReader(Component):
         Generate a batch of mono events from list of indices.
     generate_stereo_batch(batch_indices)
         Generate a batch of stereo events from list of indices.
-    get_tel_pointing(file, tel_ids)
-        Retrieve the telescope pointing information for the specified telescope IDs.
+    get_tel_pointing(file, tel_id)
+        Retrieve the telescope pointing information for the specified telescope ID.
     close_files()
         Close all open files.
     """
@@ -490,7 +490,7 @@ class DLDataReader(Component):
                         keys=["obs_id", "event_id"],
                     )
                     # Add the spherical offsets w.r.t. to the telescope pointing
-                    tel_pointing = self.get_tel_pointing(f, [tel_id])
+                    tel_pointing = self.get_tel_pointing(f, tel_id)
                     tel_table = join(
                         left=tel_table,
                         right=tel_pointing,
@@ -618,7 +618,7 @@ class DLDataReader(Component):
                         keys=["obs_id", "event_id"],
                     )
                     if self.process_type == ProcessType.Simulation:
-                        tel_pointing = self.get_tel_pointing(f, [tel_id])
+                        tel_pointing = self.get_tel_pointing(f, tel_id)
                         merged_table = join(
                             left=merged_table,
                             right=tel_pointing,
@@ -699,7 +699,7 @@ class DLDataReader(Component):
         # waiting astropy v7.0.0
         # self.example_identifiers.add_index(["obs_id", "event_id"])
 
-    def get_tel_pointing(self, file, tel_ids) -> Table:
+    def get_tel_pointing(self, file, tel_id) -> Table:
         """
         Retrieve the telescope pointing information for the specified telescope IDs.
 
@@ -710,24 +710,20 @@ class DLDataReader(Component):
         -----------
         file : str
             Path to the file containing the telescope pointing data.
-        tel_ids : list
-            List of telescope IDs for which the pointing information is to be retrieved.
+        tel_id : int
+            Telescope ID for which the pointing information is to be retrieved.
 
         Returns:
         --------
         tel_pointing : astropy.table.Table
             A table containing pointing information (azimuth and altitude) for each telescope.
         """
-        tel_pointing = []
-        for tel_id in tel_ids:
-            with lock:
-                tel_pointing.append(
-                    read_table(
-                        file,
-                        f"/configuration/telescope/pointing/tel_{tel_id:03d}",
-                    )
-                )
-        return vstack(tel_pointing)
+        with lock:
+            tel_pointing = read_table(
+                file,
+                f"/configuration/telescope/pointing/tel_{tel_id:03d}",
+            )
+        return tel_pointing
 
     def get_array_pointing(self, file) -> Table:
         """

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -25,7 +25,7 @@ import threading
 
 from astropy import units as u
 from astropy.coordinates.earth import EarthLocation
-from astropy.coordinates import SkyCoord
+from astropy.coordinates import AltAz, SkyCoord
 from astropy.table import (
     Table,
     unique,
@@ -34,6 +34,7 @@ from astropy.table import (
 )
 from astropy.time import Time
 
+from ctapipe.coordinates import CameraFrame
 from ctapipe.core import Component, QualityQuery
 from ctapipe.core.traits import (
     Bool,
@@ -51,13 +52,6 @@ from ctapipe.instrument import SubarrayDescription
 from ctapipe.io import read_table
 from dl1_data_handler.image_mapper import ImageMapper
 
-# Reference (dummy) location to insert in the SkyCoord object as the default location
-#: Area averaged position of LST-1, MAGIC-1 and MAGIC-2 (using 23**2 and 17**2 m2)
-REFERENCE_LOCATION = EarthLocation(
-    lon=-17.890879 * u.deg,
-    lat=28.761579 * u.deg,
-    height=2199 * u.m,  # MC obs-level
-)
 # Reference (dummy) time to insert in the SkyCoord object as the default time
 LST_EPOCH = Time("2018-10-01T00:00:00", scale="utc")
 
@@ -227,7 +221,6 @@ class DLDataReader(Component):
         parent=None,
         **kwargs,
     ):
-
         super().__init__(config=config, parent=parent, **kwargs)
 
         # Register the destructor to close all open files properly
@@ -576,14 +569,11 @@ class DLDataReader(Component):
         simulation_info = []
         example_identifiers = []
         for file_idx, (filename, f) in enumerate(self.files.items()):
-            if self.process_type == ProcessType.Simulation:
-                # Read simulation information for each observation
-                simulation_info.append(read_table(f, "/configuration/simulation/run"))
-                # Construct the shower simulation table
-                simshower_table = read_table(f, "/simulation/event/subarray/shower")
             # Read the trigger table.
             trigger_table = read_table(f, "/dl1/event/subarray/trigger")
             if self.process_type == ProcessType.Simulation:
+                # Construct the shower simulation table
+                simshower_table = read_table(f, "/simulation/event/subarray/shower")
                 # The shower simulation table is joined with the subarray trigger table.
                 trigger_table = join(
                     left=trigger_table,
@@ -627,7 +617,7 @@ class DLDataReader(Component):
                         right=tel_pointing,
                         keys=["obs_id", "tel_id"],
                     )
-                    table_per_type = self._transform_to_spherical_offsets(
+                    table_per_type = self._transform_to_cam_coord_offsets(
                         table_per_type
                     )
                 # Apply the multiplicity cut based on the telescope type
@@ -663,6 +653,24 @@ class DLDataReader(Component):
                 events.add_column(
                     true_shower_primary_class, name="true_shower_primary_class"
                 )
+                # Read simulation information for each observation
+                simulation_info_table = read_table(f, "/configuration/simulation/run")
+                # Append the simulation information to the list of simulation information
+                simulation_info.append(simulation_info_table)
+                # Assuming min_az = max_az and min_alt = max_alt
+                fix_array_pointing = simulation_info_table.copy()
+                fix_array_pointing.keep_columns(["obs_id", "min_az", "min_alt"])
+                fix_array_pointing.rename_column("min_az", "pointing_azimuth")
+                fix_array_pointing.rename_column("min_alt", "pointing_altitude")
+                # Join the prediction table with the telescope pointing table
+                events = join(
+                    left=events,
+                    right=fix_array_pointing,
+                    keys=["obs_id"],
+                )
+                # TODO: use keep_order for astropy v7.0.0
+                events.sort(["obs_id", "event_id"])
+                events = self._transform_to_sky_spher_offsets(events)
             # Appending the events to the list of example identifiers
             example_identifiers.append(events)
 
@@ -741,9 +749,9 @@ class DLDataReader(Component):
         table.add_column(np.log10(table["true_energy"]), name="log_true_energy")
         return table
 
-    def _transform_to_spherical_offsets(self, table) -> Table:
+    def _transform_to_cam_coord_offsets(self, table) -> Table:
         """
-        Transform Alt/Az coordinates to spherical offsets w.r.t. the telescope pointing.
+        Transform Alt/Az coordinates to camera coordinate offsets w.r.t. the telescope pointing.
 
         This method converts the Alt/Az coordinates in the provided table to spherical offsets
         w.r.t. the telescope pointing. It also calculates the angular separation between the
@@ -758,34 +766,98 @@ class DLDataReader(Component):
         --------
         table : astropy.table.Table
             A Table with the spherical offsets and the angular separation added as new columns.
-            The telescope pointing columns are removed from the table.
+        """
+
+        tel_tables = []
+        for tel_id in self.tel_ids:
+            tel_table = table.copy()
+            tel_table.keep_columns(
+                [
+                    "obs_id",
+                    "tel_id",
+                    "true_alt",
+                    "true_az",
+                    "telescope_pointing_azimuth",
+                    "telescope_pointing_altitude",
+                ]
+            )
+            tel_table = tel_table[tel_table["tel_id"] == tel_id]
+            # Set the telescope pointing of the SkyOffsetSeparation tranform to the fix pointing
+            tel_ground_frame = self.subarray.tel_coords[
+                self.subarray.tel_ids_to_indices(tel_id)
+            ]
+            fix_tel_pointing = SkyCoord(
+                tel_table["telescope_pointing_azimuth"],
+                tel_table["telescope_pointing_altitude"],
+                location=tel_ground_frame.to_earth_location(),
+                obstime=LST_EPOCH,
+            )
+            camera_frame = CameraFrame(
+                focal_length=self.subarray.tel[tel_id].optics.equivalent_focal_length,
+                rotation=self.subarray.tel[tel_id].camera.geometry.pix_rotation,
+                telescope_pointing=fix_tel_pointing,
+            )
+            # Transform the true Alt/Az coordinates to camera coordinates
+            true_direction = SkyCoord(
+                tel_table["true_az"],
+                tel_table["true_alt"],
+                location=tel_ground_frame.to_earth_location(),
+                obstime=LST_EPOCH,
+            )
+            true_cam_position = true_direction.transform_to(camera_frame)
+            true_cam_distance = np.sqrt(
+                true_cam_position.x**2 + true_cam_position.y**2
+            )
+            tel_table.add_column(true_cam_position.x, name="cam_coord_offset_x")
+            tel_table.add_column(true_cam_position.y, name="cam_coord_offset_y")
+            tel_table.add_column(true_cam_distance, name="cam_coord_distance")
+            tel_tables.append(tel_table)
+        tel_tables = vstack(tel_tables)
+        table = join(
+            left=table,
+            right=tel_tables,
+            keys=["obs_id", "event_id", "tel_id"],
+        )
+        # TODO: use keep_order for astropy v7.0.0
+        table.sort(["obs_id", "event_id", "tel_id"])
+        return table
+
+    def _transform_to_sky_spher_offsets(self, table) -> Table:
+        """
+        Transform Alt/Az coordinates to sky spherical offsets w.r.t. the telescope pointing.
+
+        This method converts the Alt/Az coordinates in the provided table to sky spherical offsets
+        w.r.t. the telescope pointing. It also calculates the angular separation between the
+        true and telescope pointing directions.
+
+        Parameters:
+        -----------
+        table : astropy.table.Table
+            A Table containing the true Alt/Az coordinates and telescope pointing.
+
+        Returns:
+        --------
+        table : astropy.table.Table
+            A Table with the spherical offsets and the angular separation added as new columns.
         """
         # Set the telescope pointing of the SkyOffsetSeparation tranform to the fix pointing
-        fix_pointing = SkyCoord(
-            table["telescope_pointing_azimuth"],
-            table["telescope_pointing_altitude"],
-            frame="altaz",
-            location=REFERENCE_LOCATION,
+        fix_array_pointing = SkyCoord(
+            table["pointing_azimuth"],
+            table["pointing_altitude"],
+            location=self.subarray.reference_location,
             obstime=LST_EPOCH,
         )
         true_direction = SkyCoord(
             table["true_az"],
             table["true_alt"],
-            frame="altaz",
-            location=REFERENCE_LOCATION,
+            location=self.subarray.reference_location,
             obstime=LST_EPOCH,
         )
         sky_offset = fix_pointing.spherical_offsets_to(true_direction)
         angular_separation = fix_pointing.separation(true_direction)
-        table.add_column(sky_offset[0], name="spherical_offset_az")
-        table.add_column(sky_offset[1], name="spherical_offset_alt")
-        table.add_column(angular_separation, name="angular_separation")
-        table.remove_columns(
-            [
-                "telescope_pointing_azimuth",
-                "telescope_pointing_altitude",
-            ]
-        )
+        table.add_column(sky_offset[0], name="sky_offset_lon")
+        table.add_column(sky_offset[1], name="sky_offset_lat")
+        table.add_column(angular_separation, name="sky_angular_separation")
         return table
 
     def get_parameters(self, batch, dl1b_parameter_list) -> np.array:
@@ -901,7 +973,9 @@ class DLDataReader(Component):
         batch = self._append_features(batch)
         # Add blank inputs for missing telescopes in the batch
         if self.process_type == ProcessType.Simulation:
-            batch_grouped = batch.group_by(["obs_id", "event_id", "true_shower_primary_class"])
+            batch_grouped = batch.group_by(
+                ["obs_id", "event_id", "true_shower_primary_class"]
+            )
         elif self.process_type == ProcessType.Observation:
             batch_grouped = batch.group_by(["obs_id", "event_id"])
         for group_element in batch_grouped.groups:
@@ -927,13 +1001,13 @@ class DLDataReader(Component):
                         if "features" in group_element.colnames:
                             blank_input_row["features"] = blank_input
                         if "mono_feature_vectors" in group_element.colnames:
-                            blank_input_row["mono_feature_vectors"] = (
-                                blank_mono_feature_vectors
-                            )
+                            blank_input_row[
+                                "mono_feature_vectors"
+                            ] = blank_mono_feature_vectors
                         if "stereo_feature_vectors" in group_element.colnames:
-                            blank_input_row["stereo_feature_vectors"] = (
-                                blank_stereo_feature_vectors
-                            )
+                            blank_input_row[
+                                "stereo_feature_vectors"
+                            ] = blank_stereo_feature_vectors
                         batch.add_row(blank_input_row)
         # Sort the batch with the new rows of blank inputs
         batch.sort(["obs_id", "event_id", "tel_type_id", "tel_id"])
@@ -941,11 +1015,12 @@ class DLDataReader(Component):
 
     def __destructor(self):
         """Destructor to ensure all opened HDF5 files are properly closed."""
-        if hasattr(self, "files"):  # Ensure self.files exists before attempting to close
+        if hasattr(
+            self, "files"
+        ):  # Ensure self.files exists before attempting to close
             for file_name in list(self.files.keys()):
                 if self.files[file_name].isopen:  # Check if file is still open
                     self.files[file_name].close()
-
 
     @abstractmethod
     def _append_features(self, batch) -> Table:
@@ -1078,7 +1153,6 @@ class DLImageReader(DLDataReader):
         parent=None,
         **kwargs,
     ):
-
         super().__init__(
             input_url_signal=input_url_signal,
             input_url_background=input_url_background,
@@ -1337,7 +1411,6 @@ class DLWaveformReader(DLDataReader):
         parent=None,
         **kwargs,
     ):
-
         super().__init__(
             input_url_signal=input_url_signal,
             input_url_background=input_url_background,

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -731,7 +731,7 @@ class DLDataReader(Component):
                 )
         return vstack(tel_pointing)
 
-    def get_array_pointing(self, file) -> Table
+    def get_array_pointing(self, file) -> Table:
         """
         Retrieve the array pointing information.
 

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -749,7 +749,7 @@ class DLDataReader(Component):
             A table containing array pointing information (azimuth and altitude).
         """
         # Read simulation information for each observation
-        array_ppointing = read_table(file, "/configuration/simulation/run")
+        array_pointing = read_table(file, "/configuration/simulation/run")
         # Assuming min_az = max_az and min_alt = max_alt
         array_pointing = simulation_info_table.copy()
         array_pointing.keep_columns(["obs_id", "min_az", "min_alt"])

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -751,7 +751,6 @@ class DLDataReader(Component):
         # Read simulation information for each observation
         array_pointing = read_table(file, "/configuration/simulation/run")
         # Assuming min_az = max_az and min_alt = max_alt
-        array_pointing = simulation_info_table.copy()
         array_pointing.keep_columns(["obs_id", "min_az", "min_alt"])
         array_pointing.rename_column("min_az", "pointing_azimuth")
         array_pointing.rename_column("min_alt", "pointing_altitude")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 
 requires-python = ">=3.10"
 dependencies = [
-    "ctapipe==0.23.2",
+    "ctapipe>=0.22, <0.24",
     "astropy",
     "numpy",
     "pandas",


### PR DESCRIPTION
This PR adopts the handling of coordinate frames from `ctapipe`. Labeling this as a bug fix since those changes are really necessary for the correct transformation back to alt az coordinates and for properly handling stereo data.

Closes #145