### PR TITLE
Add option to force dl1 lookup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ necessary package channels, and install dl1-data-handler specified version and i
 
 .. code-block:: bash
 
-   DL1DH_VER=0.14.3
+   DL1DH_VER=0.14.4
    wget https://raw.githubusercontent.com/cta-observatory/dl1-data-handler/v$DL1DH_VER/environment.yml
    conda env create -n [ENVIRONMENT_NAME] -f environment.yml
    conda activate [ENVIRONMENT_NAME]

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
     - numpy
     - scipy
     - pip
-    - ctapipe==0.25.0
+    - ctapipe==0.25.1
     - traitlets
     - pyyaml
     - pandas


### PR DESCRIPTION
This PR adds an option to retrieve the table index from the dl1 image table. The default option is False since it should only be used whenever strict ordering is not guaranteed. I'd need this functionality "repair" existing data files (4LSTs datasets).