### PR TITLE
Fix duplicates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ necessary package channels, and install dl1-data-handler specified version and i
 
 .. code-block:: bash
 
-   DL1DH_VER=0.14.4
+   DL1DH_VER=0.14.5
    wget https://raw.githubusercontent.com/cta-observatory/dl1-data-handler/v$DL1DH_VER/environment.yml
    conda env create -n [ENVIRONMENT_NAME] -f environment.yml
    conda activate [ENVIRONMENT_NAME]

--- a/dl1_data_handler/reader.py
+++ b/dl1_data_handler/reader.py
@@ -536,6 +536,8 @@ class DLDataReader(Component):
                     dl1_tel_table.add_column(
                         np.arange(len(dl1_tel_table)), name="table_index", index=0
                     )
+                    # Unique the table to remove unwanted duplication 
+                    dl1_tel_table = unique(dl1_tel_table, keys=["obs_id", "event_id", "tel_id"])
                     # Join the DL1 image table with the DL1 parameter table
                     tel_table = join(
                         left=tel_table,
@@ -673,6 +675,8 @@ class DLDataReader(Component):
                         dl1_tel_table.add_column(
                             np.arange(len(dl1_tel_table)), name="table_index", index=0
                         )
+                        # Unique the table to remove unwanted duplication
+                        dl1_tel_table = unique(dl1_tel_table, keys=["obs_id", "event_id", "tel_id"])
                         # Join the DL1 image table with the DL1 parameter table
                         tel_table = join(
                             left=tel_table,


### PR DESCRIPTION
Sometimes (very rarely) simtel writes duplication of events (maybe slurm glitches but it is unknown, observed with same LST sims discussed in [ctapipe#2344](https://github.com/cta-observatory/ctapipe/issues/2344), but also for regular LST-1 sims). Normally, it is caught by diagnostic scripts. However, if there are just a few duplications the script may pass. Therefore, we have problems later on. The dl1_lookup flag is for repairing existing simtel productions.