### PR TITLE
remove allow_failure for python 3.14

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -22,7 +22,7 @@ jobs:
       max-parallel: 6
     runs-on: ${{ matrix.os }}
     # Allow failures for nightly ctapipe or 3.14 builds
-    continue-on-error: ${{ matrix.ctapipe-version == 'nightly' || matrix.python-version == '3.14' }}
+    continue-on-error: ${{ matrix.ctapipe-version == 'nightly'}}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -21,7 +21,7 @@ jobs:
         ctapipe-version: ['0.25.0', 'latest', 'nightly']
       max-parallel: 6
     runs-on: ${{ matrix.os }}
-    # Allow failures for nightly ctapipe or 3.14 builds
+    # Allow failures for nightly ctapipe builds
     continue-on-error: ${{ matrix.ctapipe-version == 'nightly'}}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
pytables 3.11.X has been released which supports python 3.14. So we can remove the allow_failure for this version 